### PR TITLE
Video pull bugs fixes

### DIFF
--- a/web2py/applications/smc/models/b_media_code.py
+++ b/web2py/applications/smc/models/b_media_code.py
@@ -139,14 +139,14 @@ def check_proxy(proxy_url, timeout=5):
 
 
 
-def get_youtube_proxies(randomize=False, verify_tcp=True, tcp_timeout=5):
+def get_youtube_proxies(randomize=False, verify_tcp=True, tcp_timeout=5, max_proxies=5):
     """Return enabled proxy_url strings from youtube_proxy_list.
 
     When verify_tcp is True (default), each candidate must accept a TCP connection
     to its host:port; unreachable rows are skipped and last_error_on is updated.
     Set verify_tcp=False only if you need the raw DB list (e.g. admin tooling).
     """
-    # Skip proxies if they have had a 429 error less than this
+    # Skip proxies if they have had an error less than this
     not_before = datetime.datetime.now() - datetime.timedelta(minutes=10)
 
     query = (db.youtube_proxy_list.enabled==True)
@@ -157,7 +157,7 @@ def get_youtube_proxies(randomize=False, verify_tcp=True, tcp_timeout=5):
         rows = db(query).select(orderby=db.youtube_proxy_list.last_request_on)
     ret = list()
     for row in rows:
-        if row.last_429_error_on is None or row.last_429_error_on < not_before:
+        if row.last_error_on is None or row.last_error_on < not_before:
             url = row["proxy_url"]
             if verify_tcp:
                 ok, check_msg = check_proxy(url, timeout=tcp_timeout)
@@ -172,8 +172,10 @@ def get_youtube_proxies(randomize=False, verify_tcp=True, tcp_timeout=5):
                         pass
                     continue
             ret.append(url)
+            if len(ret) >= max_proxies:
+                break
         else:
-            print(f"Skipping proxy - too soon since since last 429 error: {row.proxy_url}")
+            print(f"Skipping proxy - too soon since since last error: {row.proxy_url}")
 
     return ret
 

--- a/web2py/applications/smc/models/b_media_code.py
+++ b/web2py/applications/smc/models/b_media_code.py
@@ -20,6 +20,7 @@ import mimetypes
 import tempfile
 from ednet.canvas import Canvas
 from pytubefix import YouTube
+from urllib.parse import urlparse
 
 
 # Help shut up pylance warnings
@@ -110,19 +111,16 @@ def set_session_value(namespace="ui", control=None, key=None, value=None):
 
 
 def check_proxy(proxy_url, timeout=5):
-    """ Quick TCP reachability for an http(s) proxy URL like "http://1.2.3.4:35000".
-    Returns (ok: bool, msg: str).
+    """ Quick TCP reachability for an http(s) proxy URL like "http://1.2.3.4:35000"
+    or "http://user:pass@host:port". Returns (ok: bool, msg: str).
     """
     if not proxy_url:
         return False, "empty proxy url"
 
     try:
-        host, port_s = proxy_url.split("//", 1)[-1].split(":")
-        try:
-            port = int(port_s)
-        except ValueError:
-                port = None
-        print(f"host: {host}, port: {port}")
+        parsed = urlparse(proxy_url)
+        host = parsed.hostname
+        port = parsed.port
         if not host or not port:
             return False, f"could not parse host/port from proxy url: {proxy_url}"
     except Exception as ex:

--- a/web2py/applications/smc/models/x_scheduler.py
+++ b/web2py/applications/smc/models/x_scheduler.py
@@ -344,7 +344,6 @@ def find_best_yt_stream(yt_url, media_file=None):
     # Change out embed for watch so the link works properly
     yt_url_tmp = yt_url.replace("/embed/", "/watch?v=")
     proxies = get_youtube_proxies(randomize=True, max_proxies=5)
-    print(f"Proxies: {proxies}")
     if not proxies:
         msg = (
             "WARNING: No valid/reachable YouTube proxy found (TCP check failed for all "
@@ -422,7 +421,7 @@ def find_best_yt_stream(yt_url, media_file=None):
                 )
                 db.commit()
             msg = (
-                f"YouTube bot detection on {yt_url} (proxy={proxy}) -- {ex}. "
+                f"YouTube bot detection on {yt_url} (proxy={hostname}:{port}) -- {ex}. "
             )
             session.yt_urls_error_msg += msg
             print(msg)
@@ -1376,7 +1375,7 @@ def pull_youtube_video(media_file, force_video=False, force_captions=False):
             print(f"Unknown HTTP error pulling yt video? {yt_url}\n{ex}")
             log_to_video(media_file, f"Unknown Error - Failed to download video from {yt_url}, will keep trying.\n{ex}")
             media_file.needs_downloading = True
-            media_file.download_failures = media_file.get("download_failures", 0) or 0 + 1
+            media_file.download_failures = media_file.get("download_failures", 0) + 1
             media_file.update_record()
             db.commit()
             return False
@@ -1483,7 +1482,7 @@ def pull_youtube_video(media_file, force_video=False, force_captions=False):
                     media_file.update_record()
                     db.commit()                
                     return True
-                elif return_code == "Termporary Error":
+                elif return_code == "Temporary Error":
                     print(f"Temporary Error - Unable to get captions {yt_url}.")
                     log_to_video(media_file, f"Failed to download captions from {yt_url}, will keep trying.")
                     media_file.needs_caption_downloading = True

--- a/web2py/applications/smc/models/x_scheduler.py
+++ b/web2py/applications/smc/models/x_scheduler.py
@@ -12,6 +12,7 @@ import traceback
 import pytubefix, pytubefix.exceptions
 pytube = pytubefix
 import datetime
+from urllib.parse import urlparse
 
 # Help shut up pylance warnings
 if 1==2: from ..common import *
@@ -342,7 +343,8 @@ def find_best_yt_stream(yt_url, media_file=None):
 
     # Change out embed for watch so the link works properly
     yt_url_tmp = yt_url.replace("/embed/", "/watch?v=")
-    proxies = get_youtube_proxies()
+    proxies = get_youtube_proxies(randomize=True, max_proxies=5)
+    print(f"Proxies: {proxies}")
     if not proxies:
         msg = (
             "WARNING: No valid/reachable YouTube proxy found (TCP check failed for all "
@@ -353,8 +355,10 @@ def find_best_yt_stream(yt_url, media_file=None):
         log_to_video(media_file, msg)
         proxies = [None]
 
-    for proxy in proxies[0:5]:  # Only try the first 5 proxies - don't try forever
+    for proxy in proxies:
         # Try each proxy in order trying to get this video.
+        hostname = urlparse(proxy).hostname
+        port = urlparse(proxy).port
         proxy_item = db(db.youtube_proxy_list.proxy_url==proxy).select().first()
         if proxy_item:
             db(db.youtube_proxy_list.id==proxy_item.id).update(
@@ -363,19 +367,17 @@ def find_best_yt_stream(yt_url, media_file=None):
             db.commit()
         try:
             if proxy is not None:
-                msg = f"Trying to get {yt_url} from proxy {proxy}"
-            else:
-                msg = f"Trying to get {yt_url} without proxy (no reachable proxy in pool)"
-            print(msg)
-            log_to_video(media_file, msg)
-            if proxy is not None:
+                msg = f"Trying to get {yt_url} from proxy {hostname}:{port}"
                 # Youtube proxy wants it in p['https']='https://123.123.321.321:35000' form
                 p = {
                     'https': proxy,
                     'http': proxy,
                 }
             else:
+                msg = f"Trying to get {yt_url} without proxy (no reachable proxy in pool)"
                 p = None
+            print(msg)
+            log_to_video(media_file, msg)
 
             # Align process-global urllib opener (pytubefix uses install_opener); direct = empty handler.
             try:
@@ -395,17 +397,14 @@ def find_best_yt_stream(yt_url, media_file=None):
     
             s = yt.streams.filter(file_extension='mp4', progressive=True, res=res).first()
             if s is None:
-                # Try 360p
                 res = '360p'
                 s = yt.streams.filter(file_extension='mp4', progressive=True, res=res).first()
             if s is None:
-                # Try 720p
                 res = '720p'
                 s = yt.streams.filter(file_extension='mp4', progressive=True, res=res).first()
             if s is None:
                 # If that doesn't exist, then get the first one in the list
                 s = yt.streams.filter(file_extension='mp4', progressive=True).first()
-            # s.download()  # put in folder name
     
             stream = s
 
@@ -413,7 +412,10 @@ def find_best_yt_stream(yt_url, media_file=None):
             return_code = "OK"
             return yt, stream, res, return_code
 
-        except pytube.exceptions.BotDetection as ex:
+        except (
+            pytube.exceptions.BotDetection,
+            pytube.exceptions.VideoRegionBlocked,
+        ) as ex:
             if proxy_item:
                 db(db.youtube_proxy_list.id==proxy_item.id).update(
                     last_error_on = datetime.datetime.now()
@@ -426,8 +428,7 @@ def find_best_yt_stream(yt_url, media_file=None):
             print(msg)
             traceback.print_exc()
             log_to_video(media_file, msg)
-            return_code = "Bot Detection"
-            return yt, stream, res, return_code
+            # Try next proxy in list - don't return yet
 
         ## These exceptions mean we can't get it - don't keep trying other proxies
         except (
@@ -436,7 +437,6 @@ def find_best_yt_stream(yt_url, media_file=None):
             pytube.exceptions.MembersOnly,
             pytube.exceptions.RecordingUnavailable,
             pytube.exceptions.VideoPrivate,
-            pytube.exceptions.VideoRegionBlocked,
             pytube.exceptions.VideoUnavailable,
             pytube.exceptions.MaxRetriesExceeded,
         ) as ex:
@@ -453,7 +453,6 @@ def find_best_yt_stream(yt_url, media_file=None):
             return_code = "Permanent Error"
 
             return yt, stream, res, return_code
-            #raise Exception(msg)
 
 
         ## These exceptions mean there as a parsing/temp error - don't keep trying other proxies
@@ -474,11 +473,6 @@ def find_best_yt_stream(yt_url, media_file=None):
             log_to_video(media_file, msg)
             return_code = "Termporary Error"
             return yt, stream, res, return_code
-        
-        
-        # Other exceptions inherit from this - just catch a general exception
-        #except pytube.exceptions.PytubeError as ex:
-        #    pass        
                 
         except HTTPError as ex:
             if ex.code == 429:  # Do we need this w max retries?


### PR DESCRIPTION
## PR Title

Fix YouTube video pull proxy handling, logging, and error recovery

---

## Summary

This branch fixes several bugs in the YouTube video pull pipeline around proxy selection, error handling, and failure counting. Changes span `b_media_code.py` (proxy utilities) and `x_scheduler.py` (`find_best_yt_stream` / `pull_youtube_video`).

- **Proxy URL parsing** — `check_proxy` now uses `urllib.parse.urlparse` instead of manual string splitting, so proxies with credentials (`http://user:pass@host:port`) parse correctly. Debug `print` of host/port was removed.
- **Proxy pool selection** — `get_youtube_proxies` adds a `max_proxies` parameter (default 5), uses `last_error_on` instead of `last_429_error_on` for the 10-minute cooldown, and `find_best_yt_stream` calls it with `randomize=True` so proxy attempts are spread across the pool.
- **Retry on bot detection / region block** — `BotDetection` and `VideoRegionBlocked` no longer abort the proxy loop immediately; the code tries the next proxy instead of returning early. `VideoRegionBlocked` was removed from the permanent-error group.
- **Logging** — Proxy attempts and errors log `hostname:port` instead of the full proxy URL, avoiding credentials in logs.
- **Failure counting** — Fixes `download_failures` increment in the unknown-exception path: `get("download_failures", 0) + 1` instead of `get(...) or 0 + 1` (which always yielded 1).

